### PR TITLE
Better multiline handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Changelog
 0.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Multiline options do not need an indent of 4 spaces, one is enough.
+  Now this script correctly identifies them
+  [do3cc]
 
 
 0.2.0 (2015-09-11)

--- a/src/collective/normalize_buildout/cmd.py
+++ b/src/collective/normalize_buildout/cmd.py
@@ -11,7 +11,7 @@ import sys
 is_section = re.compile(r'^\[(.*)\]')
 is_comment = re.compile(r'^#.*')
 is_option = re.compile(r'^(\S+) *[+-=]')
-is_nextline_option = re.compile(r'^    ')
+is_nextline_option = re.compile(r'^ +')
 
 
 logger = logging.getLogger(__name__)

--- a/src/collective/normalize_buildout/tests/test_script.py
+++ b/src/collective/normalize_buildout/tests/test_script.py
@@ -81,3 +81,22 @@ extra-field-types =
 '''.strip()  # NOQA
 
         self.assertEqual(expected, output.read())
+
+    def test_regression3(self):
+        cfg = self.given_a_file_in_test_dir('buildout.cfg', '''
+[filter]
+extra-field-types =
+ <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(/)+$" replacement=""/>
+'''.strip())  # NOQA
+        output = StringIO()
+
+        sort(file(cfg), output)
+        output.seek(0)
+
+        expected = '''
+[filter]
+extra-field-types =
+ <charFilter class="solr.PatternReplaceCharFilterFactory" pattern="(/)+$" replacement=""/>
+'''.strip()  # NOQA
+
+        self.assertEqual(expected, output.read())


### PR DESCRIPTION
Multiline values don't need an indent of 4 spaces.
